### PR TITLE
Add travis to build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+sudo: required
+services:
+  - docker
+
+jobs:
+  include:
+    - stage: test
+      env: Type='bindgen test'
+      script:
+        - docker run -d -it --name libzfs -v $(pwd):/rust-libzfs:rw intelhpdd/libzfs:version1.0
+        - docker exec -i libzfs bash -c 'source $HOME/.cargo/env && cd /rust-libzfs/node-libzfs && cargo build'
+        - docker exec -i libzfs bash -c 'source $HOME/.cargo/env && cd /rust-libzfs/libzfs-sys && cargo test bindgen_test_layout'
+    - stage: test
+      env: Type='virus scan'
+      script:
+        - sudo apt-get install clamav -y
+        - sudo freshclam
+        - clamscan --quiet -r ./
+    - stage: test
+      env: Type='ts2fable'
+      language: csharp
+      dotnet: 2.1.2
+      mono: latest
+      script:
+        - nvm install 8
+        - npm i -g ts2fable
+        - ts2fable $(pwd)/node-libzfs/lib/libzfs.d.ts $(pwd)/node-libzfs/lib/out.fs
+    - stage: deploy
+      env: Type='libzfs-sys'
+      language: rust
+      rust: stable
+      if: branch = master AND tag =~ ^v.+libzfs-sys$
+      script:
+        - docker run -d -it --name libzfs -v $(pwd):/rust-libzfs:rw intelhpdd/libzfs:version1.0
+        - docker exec -i libzfs bash -c "source /root/.cargo/env && cd /rust-libzfs/libzfs-sys && cargo package"
+        - cd $(pwd)/libzfs-sys && cargo publish --token $CARGO_TOKEN

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # rust-libzfs
 
-This lib repo provides [bindings](libzfs-sys) from libzfs to rust using bindgen.
+[![Build Status](https://travis-ci.org/intel-hpdd/rust-libzfs.svg?branch=master)](https://travis-ci.org/intel-hpdd/rust-libzfs)
+
+This repo provides [bindings](libzfs-sys) from libzfs to rust using bindgen.
 It also provides a [wrapper](libzfs) around those bindings for idiomatic use.
 Additionally, it provides [node bindings](node-libzfs) around the rust wrapper.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,8 +22,7 @@ Vagrant.configure("2") do |config|
     config.vm.boot_timeout = 600
   
     config.vm.provision "shell", inline: <<-SHELL
-        yum -y install yum-plugin-copr epel-release
-        yum-config-manager --add-repo https://downloads.hpdd.intel.com/public/lustre/lustre-2.10.2/el7/server/
+        yum -y install yum-plugin-copr epel-release http://download.zfsonlinux.org/epel/zfs-release.el7_4.noarch.rpm
         yum -y copr enable alonid/llvm-5.0.0
         yum -y install clang-5.0.0 zfs libzfs2-devel --nogpgcheck
         modprobe zfs

--- a/libzfs-sys/Cargo.toml
+++ b/libzfs-sys/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "libzfs-sys"
 version = "0.1.0"
-authors = ["Joe Grund <joe.grund@intel.com>"]
+description = "Rust bindings to libzfs2"
+license = "MIT"
+repository = "https://github.com/intel-hpdd/rust-libzfs"
+authors = ["Iml Team <iml@intel.com>"]
 links = "zfs"
 build = "build.rs"
 

--- a/libzfs-sys/README.md
+++ b/libzfs-sys/README.md
@@ -1,3 +1,3 @@
 # libzfs-sys
 
-Bindings to libzfs 0.7.1. Uses [bindgen](https://github.com/rust-lang-nursery/rust-bindgen).
+Bindings to libzfs 0.7.5. Uses [bindgen](https://github.com/rust-lang-nursery/rust-bindgen).

--- a/libzfs-sys/build.rs
+++ b/libzfs-sys/build.rs
@@ -74,8 +74,8 @@ fn main() {
         .whitelisted_function("libzfs_error_description")
         .whitelisted_function("zfs_prop_get")
         .clang_arg("-I/usr/lib/gcc/x86_64-redhat-linux/4.8.2/include/")
-        .clang_arg("-I/usr/src/zfs-0.7.3/lib/libspl/include/")
-        .clang_arg("-I/usr/src/zfs-0.7.3/include/")
+        .clang_arg("-I/usr/src/zfs-0.7.5/lib/libspl/include/")
+        .clang_arg("-I/usr/src/zfs-0.7.5/include/")
         .generate()
         .expect("Unable to generate bindings");
 

--- a/libzfs/Cargo.toml
+++ b/libzfs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzfs"
 version = "0.1.0"
-authors = ["Joe Grund <joe.grund@intel.com>"]
+authors = ["IML Team <iml@intel.com>"]
 
 [dependencies]
 libzfs-sys = { path = "../libzfs-sys", version = "0.1.0" }

--- a/node-libzfs/native/Cargo.toml
+++ b/node-libzfs/native/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "node-libzfs"
 version = "0.1.0"
-authors = ["IML Team <joe.grund@intel.com>"]
+authors = ["IML Team <iml@intel.com>"]
 license = "MIT"
 build = "build.rs"
 

--- a/node-libzfs/package.json
+++ b/node-libzfs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-libzfs",
+  "name": "@iml/node-libzfs",
   "version": "0.1.0",
   "description": "Neon bindings to libzfs",
   "main": "lib/index.js",


### PR DESCRIPTION
Add a mostly comprehensive travis file that runs tests, performs a virus scan, and builds fable bindings from typescript.

 - namespace node package.
- use iml email alias
- bump to libzfs 0.7.5
- switch to building with ZOL repo.
- use docker to build bindings and test layout.

Signed-off-by: Joe Grund <joe.grund@intel.com>