### PR TITLE
Use newer nvpair update.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,12 @@ jobs:
         - docker run -d -it --name libzfs -v $(pwd):/rust-libzfs:rw intelhpdd/libzfs:version1.0
         - docker exec -i libzfs bash -c "source /root/.cargo/env && cd /rust-libzfs/libzfs-sys && cargo package"
         - cd $(pwd)/libzfs-sys && cargo publish --token $CARGO_TOKEN
+    - stage: deploy
+      env: Type='libzfs'
+      language: rust
+      rust: stable
+      if: branch =~ ^v.+libzfs$
+      script:
+        - docker run -d -it --name libzfs -v $(pwd):/rust-libzfs:rw intelhpdd/libzfs:version1.0
+        - docker exec -i libzfs bash -c "source /root/.cargo/env && cd /rust-libzfs/libzfs && cargo package"
+        - cd $(pwd)/libzfs && cargo publish --token $CARGO_TOKEN

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,8 +174,8 @@ name = "libzfs"
 version = "0.1.0"
 dependencies = [
  "libzfs-sys 0.1.0",
- "nvpair 0.2.0 (git+https://github.com/jgrund/rust-libzfs.git?rev=get-values)",
- "nvpair-sys 0.1.0 (git+https://github.com/jgrund/rust-libzfs.git?rev=get-values)",
+ "nvpair 0.3.0 (git+https://github.com/jgrund/rust-libzfs.git?rev=values-temp)",
+ "nvpair-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -172,7 +185,7 @@ name = "libzfs-sys"
 version = "0.1.0"
 dependencies = [
  "bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "nvpair-sys 0.1.0 (git+https://github.com/jgrund/rust-libzfs.git?rev=get-values)",
+ "nvpair-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -207,17 +220,18 @@ dependencies = [
 
 [[package]]
 name = "nvpair"
-version = "0.2.0"
-source = "git+https://github.com/jgrund/rust-libzfs.git?rev=get-values#8688997df5a5b1d56470c9d5045f15917f45d36c"
+version = "0.3.0"
+source = "git+https://github.com/jgrund/rust-libzfs.git?rev=values-temp#c16369ccc42bfb0b25f3bc326865d2c86f26dfb8"
 dependencies = [
  "cstr-argument 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "nvpair-sys 0.1.0 (git+https://github.com/jgrund/rust-libzfs.git?rev=get-values)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nvpair-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "nvpair-sys"
 version = "0.1.0"
-source = "git+https://github.com/jgrund/rust-libzfs.git?rev=get-values#8688997df5a5b1d56470c9d5045f15917f45d36c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "peeking_take_while"
@@ -480,6 +494,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clap 2.28.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc34bf7d5d66268b466b9852bca925ec1d2650654dab4da081e63fd230145c2e"
 "checksum cstr-argument 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "514570a4b719329df37f93448a70df2baac553020d0eb43a8dfa9c1f5ba7b658"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
+"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
@@ -489,8 +505,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
-"checksum nvpair 0.2.0 (git+https://github.com/jgrund/rust-libzfs.git?rev=get-values)" = "<none>"
-"checksum nvpair-sys 0.1.0 (git+https://github.com/jgrund/rust-libzfs.git?rev=get-values)" = "<none>"
+"checksum nvpair 0.3.0 (git+https://github.com/jgrund/rust-libzfs.git?rev=values-temp)" = "<none>"
+"checksum nvpair-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5fc4cc751960db1094a7a732dd0706927aeae9194bf66c30fa227b70fc62b6c8"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum quasi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18c45c4854d6d1cf5d531db97c75880feb91c958b0720f4ec1057135fec358b3"

--- a/libzfs-sys/Cargo.toml
+++ b/libzfs-sys/Cargo.toml
@@ -9,7 +9,7 @@ links = "zfs"
 build = "build.rs"
 
 [dependencies]
-nvpair-sys = { git = "https://github.com/jgrund/rust-libzfs.git", rev = "get-values" }
+nvpair-sys = "0.1"
 
 [build-dependencies]
 bindgen = "0.30.0"

--- a/libzfs/Cargo.toml
+++ b/libzfs/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["IML Team <iml@intel.com>"]
 
 [dependencies]
 libzfs-sys = { path = "../libzfs-sys", version = "0.1.0" }
-nvpair = { git = "https://github.com/jgrund/rust-libzfs.git", rev = "get-values" }
-nvpair-sys = { git = "https://github.com/jgrund/rust-libzfs.git", rev = "get-values" }
+nvpair = { git = "https://github.com/jgrund/rust-libzfs.git", rev = "values-temp" }
+nvpair-sys = "0.1"
 serde = "1.0"
 serde_derive = "1.0"

--- a/node-libzfs/native/Cargo.lock
+++ b/node-libzfs/native/Cargo.lock
@@ -178,6 +178,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "gcc"
 version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,8 +239,8 @@ name = "libzfs"
 version = "0.1.0"
 dependencies = [
  "libzfs-sys 0.1.0",
- "nvpair 0.2.0 (git+https://github.com/jgrund/rust-libzfs.git?rev=get-values)",
- "nvpair-sys 0.1.0 (git+https://github.com/jgrund/rust-libzfs.git?rev=get-values)",
+ "nvpair 0.3.0 (git+https://github.com/jgrund/rust-libzfs.git?rev=values-temp)",
+ "nvpair-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -237,7 +250,7 @@ name = "libzfs-sys"
 version = "0.1.0"
 dependencies = [
  "bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "nvpair-sys 0.1.0 (git+https://github.com/jgrund/rust-libzfs.git?rev=get-values)",
+ "nvpair-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -321,17 +334,18 @@ dependencies = [
 
 [[package]]
 name = "nvpair"
-version = "0.2.0"
-source = "git+https://github.com/jgrund/rust-libzfs.git?rev=get-values#8688997df5a5b1d56470c9d5045f15917f45d36c"
+version = "0.3.0"
+source = "git+https://github.com/jgrund/rust-libzfs.git?rev=values-temp#c16369ccc42bfb0b25f3bc326865d2c86f26dfb8"
 dependencies = [
  "cstr-argument 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "nvpair-sys 0.1.0 (git+https://github.com/jgrund/rust-libzfs.git?rev=get-values)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nvpair-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "nvpair-sys"
 version = "0.1.0"
-source = "git+https://github.com/jgrund/rust-libzfs.git?rev=get-values#8688997df5a5b1d56470c9d5045f15917f45d36c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "peeking_take_while"
@@ -619,6 +633,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -634,8 +650,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum neon-runtime 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "9a53b08f4dfc0ebc9ecb8bd8a02ace763e833d657f03614293254420a413c036"
 "checksum neon-serde 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "703b17ec4b5da3ffb6fbf85337df5c044ef4226beb9ac797ecfbed0e8101d8f6"
 "checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
-"checksum nvpair 0.2.0 (git+https://github.com/jgrund/rust-libzfs.git?rev=get-values)" = "<none>"
-"checksum nvpair-sys 0.1.0 (git+https://github.com/jgrund/rust-libzfs.git?rev=get-values)" = "<none>"
+"checksum nvpair 0.3.0 (git+https://github.com/jgrund/rust-libzfs.git?rev=values-temp)" = "<none>"
+"checksum nvpair-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5fc4cc751960db1094a7a732dd0706927aeae9194bf66c30fa227b70fc62b6c8"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum quasi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18c45c4854d6d1cf5d531db97c75880feb91c958b0720f4ec1057135fec358b3"

--- a/node-libzfs/native/src/lib.rs
+++ b/node-libzfs/native/src/lib.rs
@@ -100,12 +100,19 @@ fn get_pool_by_name(call: Call) -> JsResult<JsValue> {
         .check::<JsString>()?
         .value();
 
-    let p = libzfs.pool_by_name(&pool_name).unwrap();
+    let p = libzfs.pool_by_name(&pool_name);
 
-    let value = convert_to_js_pool(&p)?;
+    match p {
+        Some(x) => {
+            let value = convert_to_js_pool(&x)?;
 
-    let js_value = neon_serde::to_value(&value, scope)?;
-    Ok(js_value)
+            let js_value = neon_serde::to_value(&value, scope)?;
+
+            Ok(js_value)
+        }
+        None => Ok(JsNull::new().upcast()),
+    }
+
 }
 
 fn get_imported_pools(call: Call) -> JsResult<JsValue> {


### PR DESCRIPTION
Use an updated version of nvpair.

In addition, update node bindings to return none if a pool is not found.

Signed-off-by: Joe Grund <joe.grund@intel.com>