### PR TITLE
Add function to get uint64 nvpairs

### DIFF
--- a/libzfs/Cargo.toml
+++ b/libzfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libzfs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["IML Team <iml@intel.com>"]
 description = "Rust wrapper around libzfs-sys"
 license = "MIT"


### PR DESCRIPTION
We need to fetch dataset GUIDs, so add a function to get
uint64 nvpairs.

Signed-off-by: Joe Grund <joe.grund@intel.com>