### PR TITLE
Use newer ts2fable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
       node_js: 8
       if: branch =~ ^v.+node-libzfs$
       before_deploy:
-        - npm i -g ts2fable
+        - npm i -g ts2fable@0.6.0-build.174
         - ts2fable node-libzfs/types/@iml/node-libzfs/index.d.ts node-libzfs/libzfs.fs
         - cd node-libzfs
       deploy:

--- a/node-libzfs/native/Cargo.toml
+++ b/node-libzfs/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-libzfs"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["IML Team <iml@intel.com>"]
 license = "MIT"
 build = "build.rs"

--- a/node-libzfs/package.json
+++ b/node-libzfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iml/node-libzfs",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Neon bindings to libzfs",
   "main": "lib/index.js",
   "publishConfig": {


### PR DESCRIPTION
Make sure we use a newer ts2fable that supports scoped modules when we deploy.

Signed-off-by: Joe Grund <joe.grund@intel.com>