### PR TITLE
Add support for building rpms to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,19 @@ jobs:
       script:
         - npm i -g ts2fable@0.6.0-build.174
         - ts2fable node-libzfs/types/@iml/node-libzfs/index.d.ts node-libzfs/libzfs.fs
+    - stage: test
+      env: Type='mock build'
+      language: node_js
+      node_js: 8
+      script:
+        - cd node-libzfs
+        - npm pack
+        - rename 's/^iml\-//' iml-node-libzfs-*.tgz
+        - cd ../
+        - docker run -dit --privileged --name mock -v $(pwd):/builddir intelhpdd/mock /usr/sbin/init
+        - docker exec -ti mock bash -xec "bash -xe /builddir/node-libzfs/mock-build.sh"
+        - docker exec -ti mock bash -c "mv /var/lib/mock/epel-7-x86_64/result/*.rpm /builddir/"
+        - PACKAGE_VERSION=$(node -p -e "require('node-libzfs/package.json').version") && curl -T iml-node-libzfs-$PACKAGE_VERSION-*.el7.centos.x86_64.rpm -u$BINTRAY_USER:$BINTRAY_KEY https://api.bintray.com/content/intel-hpdd/intelhpdd-build/iml-node-libzfs/$PACKAGE_VERSION/;publish=1
     - stage: deploy
       env: Type='libzfs-sys'
       language: rust

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
         - docker run -dit --privileged --name mock -v $(pwd):/builddir intelhpdd/mock /usr/sbin/init
         - docker exec -ti mock bash -xec "bash -xe /builddir/node-libzfs/mock-build.sh"
         - docker exec -ti mock bash -c "mv /var/lib/mock/epel-7-x86_64/result/*.rpm /builddir/"
-        - PACKAGE_VERSION=$(node -p -e "require('node-libzfs/package.json').version") && curl -T iml-node-libzfs-$PACKAGE_VERSION-*.el7.centos.x86_64.rpm -u$BINTRAY_USER:$BINTRAY_KEY https://api.bintray.com/content/intel-hpdd/intelhpdd-build/iml-node-libzfs/$PACKAGE_VERSION/;publish=1
+        - PACKAGE_VERSION=$(node -p -e "require('./node-libzfs/package.json').version") && curl -T iml-node-libzfs-$PACKAGE_VERSION-*.el7.centos.x86_64.rpm -u$BINTRAY_USER:$BINTRAY_KEY https://api.bintray.com/content/intel-hpdd/intelhpdd-build/iml-node-libzfs/$PACKAGE_VERSION/;publish=1
     - stage: deploy
       env: Type='libzfs-sys'
       language: rust

--- a/node-libzfs/.gitignore
+++ b/node-libzfs/.gitignore
@@ -4,3 +4,5 @@ native/artifacts.json
 **/*~
 **/node_modules
 **/.DS_Store
+*.rpm
+*.tgz

--- a/node-libzfs/.npmignore
+++ b/node-libzfs/.npmignore
@@ -1,0 +1,2 @@
+*.spec
+mock-build.sh

--- a/node-libzfs/iml-node-libzfs.spec
+++ b/node-libzfs/iml-node-libzfs.spec
@@ -1,0 +1,57 @@
+%{?!package_release: %define package_release 1}
+
+%define base_name node-libzfs
+Name:       iml-%{base_name}
+Version:    0.1.7
+Release:    %{package_release}%{?dist}
+Summary:    Implements a binding layer from node to rust-libzfs.
+License:    MIT
+Group:      System Environment/Libraries
+URL:        https://github.com/intel-hpdd/rust-libzfs/tree/master/%{base_name}
+Source0:    http://registry.npmjs.org/@iml/%{base_name}/-/%{base_name}-%{version}.tgz
+
+ExclusiveArch: %{nodejs_arches}
+
+BuildRequires: nodejs-packaging
+BuildRequires: nodejs
+BuildRequires: npm
+BuildRequires: cargo
+BuildRequires: clang-5.0.0
+BuildRequires: libzfs2-devel
+BuildRequires: zfs
+
+Requires: nodejs
+Requires: zfs
+
+%description
+Implements a binding layer from node to rust-libzfs.
+
+%prep
+%setup -q -n package
+npm i neon-cli@0.1.22
+%nodejs_fixdep -r neon-cli
+
+%build
+npm run install
+
+%install
+mkdir -p %{buildroot}%{nodejs_sitearch}/@iml/node-libzfs/lib/
+mkdir -p %{buildroot}%{nodejs_sitearch}/@iml/node-libzfs/native/
+cp -p package.json %{buildroot}%{nodejs_sitearch}/@iml/node-libzfs/
+cp -p lib/index.js %{buildroot}%{nodejs_sitearch}/@iml/node-libzfs/lib/
+cp -p native/index.node %{buildroot}%{nodejs_sitearch}/@iml/node-libzfs/native/
+
+%clean
+rm -rf %{buildroot}
+
+%check
+%{__nodejs} -e 'require("./")'
+
+%files
+%{nodejs_sitearch}/@iml/node-libzfs/lib/index.js
+%{nodejs_sitearch}/@iml/node-libzfs/native/index.node
+%{nodejs_sitearch}/@iml/node-libzfs/package.json
+
+%changelog
+* Wed Jan 17 2018 Joe Grund <joe.grund@intel.com> - 0.1.7-1
+- initial package

--- a/node-libzfs/mock-build.sh
+++ b/node-libzfs/mock-build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -xe
+
+ed <<"EOF" /etc/mock/default.cfg
+$i
+
+[copr-be.cloud.fedoraproject.org_results_managerforlustre_manager-for-lustre_epel-7-x86_64_]
+name=added from: https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre/epel-7-x86_64/
+baseurl=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre/epel-7-x86_64/
+enabled=1
+
+[alonid-llvm-5.0.0]
+name=Copr repo for llvm-5.0.0 owned by alonid
+baseurl=https://copr-be.cloud.fedoraproject.org/results/alonid/llvm-5.0.0/epel-7-$basearch/
+enabled=1
+
+[zfs]
+name=ZFS on Linux for EL7 - dkms
+baseurl=http://download.zfsonlinux.org/epel/7.4/$basearch/
+enabled=1
+.
+w
+q
+EOF
+
+groupadd --gid $(stat -c '%g' /builddir/node-libzfs/README.md) -o mocker
+useradd --uid $(stat -c '%u' /builddir/node-libzfs/README.md) --gid $(stat -c '%g' /builddir/node-libzfs/README.md) mocker
+usermod -a -G mock mocker
+
+cd /builddir/
+RELEASE=$(git rev-list HEAD | wc -l)
+
+su - mocker <<EOF
+set -xe
+cd /builddir/node-libzfs/
+rpmbuild -bs --define epel\ 1 --define package_release\ $RELEASE --define _srcrpmdir\ \$PWD --define _sourcedir\ \$PWD *.spec
+mock iml-node-libzfs-*.src.rpm --rpmbuild-opts="--define package_release\ $RELEASE" --enable-network
+EOF

--- a/node-libzfs/mock-build.sh
+++ b/node-libzfs/mock-build.sh
@@ -33,5 +33,5 @@ su - mocker <<EOF
 set -xe
 cd /builddir/node-libzfs/
 rpmbuild -bs --define epel\ 1 --define package_release\ $RELEASE --define _srcrpmdir\ \$PWD --define _sourcedir\ \$PWD *.spec
-mock iml-node-libzfs-*.src.rpm --rpmbuild-opts="--define package_release\ $RELEASE" --enable-network
+mock iml-node-libzfs-*.src.rpm -v --rpmbuild-opts="--define package_release\ $RELEASE" --enable-network
 EOF

--- a/node-libzfs/native/Cargo.lock
+++ b/node-libzfs/native/Cargo.lock
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "node-libzfs"
-version = "0.1.4"
+version = "0.1.7"
 dependencies = [
  "libzfs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/node-libzfs/package.json
+++ b/node-libzfs/package.json
@@ -16,6 +16,11 @@
     "neon-cli": "^0.1.22"
   },
   "scripts": {
+    "premock":
+      "docker run  -dit --privileged --name mock intelhpdd/mock /usr/sbin/init",
+    "mock": "cd ../ && docker cp -a ./ mock:/builddir",
+    "postmock":
+      "docker exec -ti mock bash -xec 'bash -xe /builddir/node-libzfs/mock-build.sh'",
     "install": "neon build"
   }
 }


### PR DESCRIPTION
This patch adds support for building node-libzfs as an rpm to travis.

This enables per-patch building

Signed-off-by: Joe Grund <joe.grund@intel.com>