### PR TITLE
Add hostname / hostid to rust-libzfs

### DIFF
--- a/libzfs-sys/build.rs
+++ b/libzfs-sys/build.rs
@@ -27,6 +27,8 @@ fn main() {
         .whitelisted_var("ZPOOL_CONFIG_DEVID")
         .whitelisted_var("ZPOOL_CONFIG_WHOLE_DISK")
         .whitelisted_var("ZPOOL_CONFIG_IS_LOG")
+        .whitelisted_var("ZPOOL_CONFIG_HOSTID")
+        .whitelisted_var("ZPOOL_CONFIG_HOSTNAME")
         .whitelisted_var("VDEV_TYPE_ROOT")
         .whitelisted_var("VDEV_TYPE_MIRROR")
         .whitelisted_var("VDEV_TYPE_REPLACING")

--- a/libzfs-sys/src/lib.rs
+++ b/libzfs-sys/src/lib.rs
@@ -46,13 +46,20 @@ pub fn zpool_config_whole_disk() -> String {
     utf8_to_string(ZPOOL_CONFIG_WHOLE_DISK)
 }
 
+pub fn zpool_config_hostid() -> String {
+    utf8_to_string(ZPOOL_CONFIG_HOSTID)
+}
+
+pub fn zpool_config_hostname() -> String {
+    utf8_to_string(ZPOOL_CONFIG_HOSTNAME)
+}
+
 pub fn zfs_value() -> String {
     utf8_to_string(ZPROP_VALUE)
 }
 
 pub fn zfs_type_dataset() -> zfs_type_t {
-    zfs_type_t_ZFS_TYPE_FILESYSTEM | zfs_type_t_ZFS_TYPE_VOLUME |
-        zfs_type_t_ZFS_TYPE_SNAPSHOT
+    zfs_type_t_ZFS_TYPE_FILESYSTEM | zfs_type_t_ZFS_TYPE_VOLUME | zfs_type_t_ZFS_TYPE_SNAPSHOT
 }
 
 

--- a/libzfs/Cargo.toml
+++ b/libzfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libzfs"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["IML Team <iml@intel.com>"]
 description = "Rust wrapper around libzfs-sys"
 license = "MIT"

--- a/node-libzfs/mock-build.sh
+++ b/node-libzfs/mock-build.sh
@@ -22,11 +22,7 @@ w
 q
 EOF
 
-MOCK_GID=$(getent group mock | cut -d: -f3)
-useradd --gid $MOCK_GID mockbuild
-usermod -a -G mock mockbuild
-MOCK_UID=$(id -u mockbuild)
-chown -R $MOCK_UID:$MOCK_GID /builddir
+chown -R mockbuild:mock /builddir
 
 cd /builddir/
 RELEASE=$(git rev-list HEAD | wc -l)


### PR DESCRIPTION
Add the ability to pull hostname and hostid to rust-libzfs.

Signed-off-by: Joe Grund <joe.grund@intel.com>