### PR TITLE
Fixup hostid in node-libzfs

### DIFF
--- a/node-libzfs/iml-node-libzfs.spec
+++ b/node-libzfs/iml-node-libzfs.spec
@@ -2,7 +2,7 @@
 
 %define base_name node-libzfs
 Name:       iml-%{base_name}
-Version:    0.1.8
+Version:    0.1.9
 Release:    %{package_release}%{?dist}
 Summary:    Implements a binding layer from node to rust-libzfs.
 License:    MIT
@@ -52,5 +52,5 @@ rm -rf %{buildroot}
 %{nodejs_sitearch}/@iml/node-libzfs/package.json
 
 %changelog
-* Wed Jan 24 2018 Joe Grund <joe.grund@intel.com> - 0.1.8-1
+* Wed Jan 24 2018 Joe Grund <joe.grund@intel.com> - 0.1.9-1
 - initial package

--- a/node-libzfs/native/Cargo.toml
+++ b/node-libzfs/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-libzfs"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["IML Team <iml@intel.com>"]
 license = "MIT"
 build = "build.rs"

--- a/node-libzfs/native/src/lib.rs
+++ b/node-libzfs/native/src/lib.rs
@@ -21,7 +21,7 @@ struct Pool {
     name: String,
     uid: String,
     hostname: String,
-    hostid: u64,
+    hostid: Option<u64>,
     state: String,
     size: u64,
     vdev: VDev,
@@ -61,9 +61,7 @@ fn convert_to_js_pool(p: &Zpool) -> Result<Pool, Throw> {
         JsError::throw(Kind::Error, "Could not get hostname")
     })?;
 
-    let hostid = p.hostid().or_else(|_| {
-        JsError::throw(Kind::Error, "Could not get hostid")
-    })?;
+    let hostid = p.hostid().ok();
 
     Ok(Pool {
         name: c_string_to_string(p.name())?,

--- a/node-libzfs/package.json
+++ b/node-libzfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iml/node-libzfs",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Neon bindings to libzfs",
   "main": "lib/index.js",
   "publishConfig": {

--- a/node-libzfs/types/@iml/node-libzfs/index.d.ts
+++ b/node-libzfs/types/@iml/node-libzfs/index.d.ts
@@ -47,7 +47,7 @@ declare module 'libzfs' {
     name: string;
     uid: string;
     hostname: string;
-    hostid: number;
+    hostid: number | null;
     state: string;
     size: number;
     vdev: VDev;


### PR DESCRIPTION
`hostid` may not exist. Return `hostid` as an `Option`
to reflect this.

Signed-off-by: Joe Grund <joe.grund@intel.com>