### PR TITLE
Uppercase uid for zpools

### DIFF
--- a/node-libzfs/native/src/lib.rs
+++ b/node-libzfs/native/src/lib.rs
@@ -65,7 +65,7 @@ fn convert_to_js_pool(p: &Zpool) -> Result<Pool, Throw> {
 
     Ok(Pool {
         name: c_string_to_string(p.name())?,
-        uid: p.guid_hex(),
+        uid: p.guid_hex().to_uppercase(),
         hostname: c_string_to_string(hostname)?,
         hostid,
         state: c_string_to_string(p.state_name())?,


### PR DESCRIPTION
Make sure the uid is put to uppercase, as
that's how it's emitted in ZED.

Signed-off-by: Joe Grund <joe.grund@intel.com>