### PR TITLE
Disable datasets before export.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ jobs:
         - cd node-libzfs
         - PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
         - RELEASE=$(git rev-list HEAD | wc -l)
-        - RPM_NAME=iml-node-libzfs-$PACKAGE_VERSION-*.el7.centos.x86_64.rpm
+        - RPM_NAME=iml-node-libzfs-$PACKAGE_VERSION-$RELEASE.el7.centos.x86_64.rpm
         - npm pack
         - rename 's/^iml\-//' iml-node-libzfs-*.tgz
         - npm run mock

--- a/libzfs-sys/README.md
+++ b/libzfs-sys/README.md
@@ -1,3 +1,3 @@
 # libzfs-sys
 
-Bindings to libzfs 0.7.5. Uses [bindgen](https://github.com/rust-lang-nursery/rust-bindgen).
+Bindings to libzfs 0.7.6. Uses [bindgen](https://github.com/rust-lang-nursery/rust-bindgen).

--- a/libzfs-sys/build.rs
+++ b/libzfs-sys/build.rs
@@ -85,8 +85,8 @@ fn main() {
         .whitelisted_function("libzfs_error_description")
         .whitelisted_function("zfs_prop_get")
         .clang_arg("-I/usr/lib/gcc/x86_64-redhat-linux/4.8.2/include/")
-        .clang_arg("-I/usr/src/zfs-0.7.5/lib/libspl/include/")
-        .clang_arg("-I/usr/src/zfs-0.7.5/include/")
+        .clang_arg("-I/usr/src/zfs-0.7.6/lib/libspl/include/")
+        .clang_arg("-I/usr/src/zfs-0.7.6/include/")
         .generate()
         .expect("Unable to generate bindings");
 

--- a/libzfs-sys/build.rs
+++ b/libzfs-sys/build.rs
@@ -81,6 +81,7 @@ fn main() {
         .whitelisted_function("zfs_get_type")
         .whitelisted_function("zfs_type_to_name")
         .whitelisted_function("zfs_path_to_zhandle")
+        .whitelisted_function("zpool_disable_datasets")
         .whitelisted_function("libzfs_error_description")
         .whitelisted_function("zfs_prop_get")
         .clang_arg("-I/usr/lib/gcc/x86_64-redhat-linux/4.8.2/include/")


### PR DESCRIPTION
We need to be sure to disable datasets before exporting
so we don't get an EBUSY.

Signed-off-by: Joe Grund <joe.grund@intel.com>