### PR TITLE
Fix Hex formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "libzfs"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "cstr-argument 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/libzfs/Cargo.toml
+++ b/libzfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libzfs"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["IML Team <iml@intel.com>"]
 description = "Rust wrapper around libzfs-sys"
 license = "MIT"

--- a/libzfs/src/lib.rs
+++ b/libzfs/src/lib.rs
@@ -218,7 +218,7 @@ impl Zpool {
         self.prop_int(sys::zpool_prop_t::ZPOOL_PROP_GUID)
     }
     pub fn guid_hex(&self) -> String {
-        format!("{:#x}", self.guid())
+        format!("{:#018X}", self.guid())
     }
     pub fn size(&self) -> u64 {
         self.prop_int(sys::zpool_prop_t::ZPOOL_PROP_SIZE)
@@ -319,7 +319,7 @@ pub fn enumerate_vdev_tree(tree: &nvpair::NvList) -> Result<VDev> {
     match x {
         x if x == sys::VDEV_TYPE_DISK => {
             let guid = tree.lookup_uint64(sys::zpool_config_guid())
-                .map(|x| format!("{:#x}", x))
+                .map(|x| format!("{:#018X}", x))
                 .ok();
             let path = tree.lookup_string(sys::zpool_config_path())?.into_string()?;
             let dev_id = lookup_tree_str(tree, sys::zpool_config_dev_id())?;


### PR DESCRIPTION
ZED is left padding hex guids with 0s to 16 chars
after the `0x`.

We can do the same with the `format!` macro
in rust so we don't mismatch.

Signed-off-by: Joe Grund <joe.grund@intel.com>