### PR TITLE
Update Vdevs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
       vb.customize ["modifyvm", :id, "--memory", "512"]
       vb.name = "libzfs"
       
-      for i in 1..5 do
+      for i in 1..9 do
         disk = "./tmp/disk#{i}.vdi"
 
         unless File.exist?(disk)
@@ -33,7 +33,7 @@ Vagrant.configure("2") do |config|
         yum -y install clang-5.0.0 zfs libzfs2-devel --nogpgcheck
         modprobe zfs
         genhostid
-        zpool create test -o cachefile=none -o multihost=on /dev/sdb
+        zpool create test mirror sdb sdc cache sdd spare sde sdf
         zfs create test/ds
         zpool export test
         curl https://sh.rustup.rs -sSf > /home/vagrant/rustup.sh

--- a/libzfs-sys/build.rs
+++ b/libzfs-sys/build.rs
@@ -25,6 +25,8 @@ fn main() {
         .whitelisted_var("ZPOOL_CONFIG_TYPE")
         .whitelisted_var("ZPOOL_CONFIG_VDEV_TREE")
         .whitelisted_var("ZPOOL_CONFIG_CHILDREN")
+        .whitelisted_var("ZPOOL_CONFIG_SPARES")
+        .whitelisted_var("ZPOOL_CONFIG_L2CACHE")
         .whitelisted_var("ZPOOL_CONFIG_PATH")
         .whitelisted_var("ZPOOL_CONFIG_PHYS_PATH")
         .whitelisted_var("ZPOOL_CONFIG_DEVID")

--- a/libzfs-sys/src/lib.rs
+++ b/libzfs-sys/src/lib.rs
@@ -26,6 +26,14 @@ pub fn zpool_config_children() -> String {
     utf8_to_string(ZPOOL_CONFIG_CHILDREN)
 }
 
+pub fn zpool_config_spares() -> String {
+    utf8_to_string(ZPOOL_CONFIG_SPARES)
+}
+
+pub fn zpool_config_l2cache() -> String {
+    utf8_to_string(ZPOOL_CONFIG_L2CACHE)
+}
+
 pub fn zpool_config_path() -> String {
     utf8_to_string(ZPOOL_CONFIG_PATH)
 }


### PR DESCRIPTION
The Vdev tree is missing some info.

Namely, we should be accounting for spares and cache on the root node.

We also can add guid, state, and is_log to the file vdev to make it
easier to test with.

Signed-off-by: Joe Grund <joe.grund@intel.com>