### PR TITLE
Update Fable bindings to account for changes.

### DIFF
--- a/Fable.Import.NodeLibzfs/NodeLibzfs.fs
+++ b/Fable.Import.NodeLibzfs/NodeLibzfs.fs
@@ -1,70 +1,88 @@
-// ts2fable 0.1.9
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 module rec libzfs
 open Fable.Core
 
 let [<Import("default","@iml/node-libzfs")>] libzfs: Libzfs.IExports = jsNative
 
 module Libzfs =
-
     type [<AllowNullLiteral>] IExports =
         [<Emit("$0()")>] abstract Invoke: unit -> NodeLibzfs
 
-    type [<AllowNullLiteral>] Dataset =
-        abstract name: string with get, set
-        abstract kind: string with get, set
+    type [<AllowNullLiteral>] RootNode =
+        abstract Root: Root with get, set
+
+    type [<AllowNullLiteral>] Root =
+        abstract children: VDev list with get, set
+
+    type [<AllowNullLiteral>] FileNode =
+        abstract File: File with get, set
 
     type [<AllowNullLiteral>] File =
+        abstract guid: string option with get, set
+        abstract state: string with get, set
         abstract path: string with get, set
+        abstract is_log: bool option with get, set
+
+    type [<AllowNullLiteral>] DiskNode =
+        abstract Disk: Disk with get, set
 
     type [<AllowNullLiteral>] Disk =
+        abstract guid: string option with get, set
+        abstract state: string with get, set
         abstract path: string with get, set
         abstract dev_id: string option with get, set
         abstract phys_path: string option with get, set
         abstract whole_disk: bool option with get, set
-        abstract is_log: bool with get, set
-
-    type [<AllowNullLiteral>] Mirror =
-        abstract children: ResizeArray<VDev> with get, set
         abstract is_log: bool option with get, set
 
+    type [<AllowNullLiteral>] MirrorNode =
+        abstract Mirror: Mirror with get, set
+
+    type [<AllowNullLiteral>] Mirror =
+        abstract children: VDev list with get, set
+        abstract is_log: bool option with get, set
+
+    type [<AllowNullLiteral>] RaidZNode =
+        abstract RaidZ: RaidZ with get, set
+
     type [<AllowNullLiteral>] RaidZ =
-        abstract children: ResizeArray<VDev> with get, set
+        abstract children: VDev list with get, set
+
+    type [<AllowNullLiteral>] ReplacingNode =
+        abstract Replacing: Replacing with get, set
 
     type [<AllowNullLiteral>] Replacing =
-        abstract children: ResizeArray<VDev> with get, set
+        abstract children: VDev list with get, set
+
+    type [<AllowNullLiteral>] SpareNode =
+        abstract Spare: Spare with get, set
 
     type [<AllowNullLiteral>] Spare =
-        abstract children: ResizeArray<VDev> with get, set
+        abstract children: VDev list with get, set
 
-    type [<AllowNullLiteral>] Root =
-        abstract children: ResizeArray<VDev> with get, set
+    type [<AllowNullLiteral>] CacheNode =
+        abstract Cache: VDev list with get, set
 
+    type [<AllowNullLiteral>] Cache =
+        abstract children: VDev list with get, set
+
+    [<Erase>]
     type VDev =
-        U7<Mirror, RaidZ, Replacing, Spare, Root, Disk, File>
+        | Root of RootNode
+        | File of FileNode
+        | Disk of DiskNode
+        | Mirror of MirrorNode
+        | RaidZ of RaidZNode
+        | Replacing of ReplacingNode
+        | Spare of SpareNode
+        | Cache of CacheNode
 
-    [<RequireQualifiedAccess; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
-    module VDev =
-        let ofMirror v: VDev = v |> U7.Case1
-        let isMirror (v: VDev) = match v with U7.Case1 _ -> true | _ -> false
-        let asMirror (v: VDev) = match v with U7.Case1 o -> Some o | _ -> None
-        let ofRaidZ v: VDev = v |> U7.Case2
-        let isRaidZ (v: VDev) = match v with U7.Case2 _ -> true | _ -> false
-        let asRaidZ (v: VDev) = match v with U7.Case2 o -> Some o | _ -> None
-        let ofReplacing v: VDev = v |> U7.Case3
-        let isReplacing (v: VDev) = match v with U7.Case3 _ -> true | _ -> false
-        let asReplacing (v: VDev) = match v with U7.Case3 o -> Some o | _ -> None
-        let ofSpare v: VDev = v |> U7.Case4
-        let isSpare (v: VDev) = match v with U7.Case4 _ -> true | _ -> false
-        let asSpare (v: VDev) = match v with U7.Case4 o -> Some o | _ -> None
-        let ofRoot v: VDev = v |> U7.Case5
-        let isRoot (v: VDev) = match v with U7.Case5 _ -> true | _ -> false
-        let asRoot (v: VDev) = match v with U7.Case5 o -> Some o | _ -> None
-        let ofDisk v: VDev = v |> U7.Case6
-        let isDisk (v: VDev) = match v with U7.Case6 _ -> true | _ -> false
-        let asDisk (v: VDev) = match v with U7.Case6 o -> Some o | _ -> None
-        let ofFile v: VDev = v |> U7.Case7
-        let isFile (v: VDev) = match v with U7.Case7 _ -> true | _ -> false
-        let asFile (v: VDev) = match v with U7.Case7 o -> Some o | _ -> None
+    type [<AllowNullLiteral>] Dataset =
+        abstract name: string with get, set
+        abstract kind: string with get, set
 
     type [<AllowNullLiteral>] Pool =
         abstract name: string with get, set
@@ -75,10 +93,10 @@ module Libzfs =
         abstract state: string with get, set
         abstract size: float with get, set
         abstract vdev: VDev with get, set
-        abstract datasets: ResizeArray<Dataset> with get, set
+        abstract datasets: Dataset list with get, set
 
     type [<AllowNullLiteral>] NodeLibzfs =
         abstract getPoolByName: name: string -> Pool option
-        abstract getImportedPools: unit -> ResizeArray<Pool>
+        abstract getImportedPools: unit -> Pool list
         abstract getDatasetStringProp: name: string * prop: string -> string option
         abstract getDatasetUint64Prop: name: string * prop: string -> float option

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,4 @@
+vagrant destroy -f
 vagrant up
 vagrant ssh -c 'sudo -i -- <<EOF
 cargo install cargo-test-junit


### PR DESCRIPTION
The Fable bindings can be updated to account
for vdev changes. In addition, we can
clean them up a bit since they are no
longer auto-generated.

Signed-off-by: Joe Grund <joe.grund@intel.com>