### PR TITLE
Remove Spare and Cache as top level VDev types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "libzfs"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "cstr-argument 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Fable.Import.NodeLibzfs/Fable.Import.NodeLibzfs.fsproj
+++ b/Fable.Import.NodeLibzfs/Fable.Import.NodeLibzfs.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="Meta.props" />
   <PropertyGroup>
-    <Version>0.1.12</Version>
+    <Version>0.1.13</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/Fable.Import.NodeLibzfs/NodeLibzfs.fs
+++ b/Fable.Import.NodeLibzfs/NodeLibzfs.fs
@@ -16,6 +16,8 @@ module Libzfs =
 
     type [<AllowNullLiteral>] Root =
         abstract children: VDev list with get, set
+        abstract spares: VDev list with get, set
+        abstract cache: VDev list with get, set
 
     type [<AllowNullLiteral>] FileNode =
         abstract File: File with get, set
@@ -57,18 +59,6 @@ module Libzfs =
     type [<AllowNullLiteral>] Replacing =
         abstract children: VDev list with get, set
 
-    type [<AllowNullLiteral>] SpareNode =
-        abstract Spare: Spare with get, set
-
-    type [<AllowNullLiteral>] Spare =
-        abstract children: VDev list with get, set
-
-    type [<AllowNullLiteral>] CacheNode =
-        abstract Cache: VDev list with get, set
-
-    type [<AllowNullLiteral>] Cache =
-        abstract children: VDev list with get, set
-
     [<Erase>]
     type VDev =
         | Root of RootNode
@@ -77,8 +67,6 @@ module Libzfs =
         | Mirror of MirrorNode
         | RaidZ of RaidZNode
         | Replacing of ReplacingNode
-        | Spare of SpareNode
-        | Cache of CacheNode
 
     type [<AllowNullLiteral>] Dataset =
         abstract name: string with get, set

--- a/libzfs/Cargo.toml
+++ b/libzfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libzfs"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["IML Team <iml@intel.com>"]
 description = "Rust wrapper around libzfs-sys"
 license = "MIT"


### PR DESCRIPTION
`Spare` and `Cache` are more analogous to `children`.

As such, remove them as top level Vdev types from the enum.
In addition, make sure we don't panic if they are not found on
the root node.

Finally, clean up the tests and add some more of them.

Signed-off-by: Joe Grund <joe.grund@intel.com>