### PR TITLE
Update spec to account for rpkg in copr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ target
 /tmp
 /*.xml
 .idea/
+travis_env
+include/copr-mfl

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,11 @@ jobs:
         - ./include/travis/virus-scan.sh
     - stage: test
       env: Type='mock build'
-      language: node_js
-      node_js: 8
+      language: generic
       script:
         - cd node-libzfs
-        - npm pack
-        - rename 's/^iml\-//' iml-node-libzfs-*.tgz
+        - docker exec -ti mock bash -c "yum install -y rpkg"
+        - docker exec -ti mock bash -c "/builddir/node-libzfs rpkg make-source"
         - npm run mock
     - stage: deploy
       env: Type='libzfs-sys'
@@ -68,9 +67,6 @@ jobs:
       if: branch =~ ^v\d+\.\d+\.\d+-.+node-libzfs$
       language: generic
       env: Type='Copr deploy'
-      sudo: required
-      services:
-        - docker
       before_deploy:
         - docker pull centos:centos7
         - openssl aes-256-cbc -K $encrypted_253525cedcf6_key -iv $encrypted_253525cedcf6_iv -in include/copr-mfl.enc -out include/copr-mfl -d
@@ -79,6 +75,6 @@ jobs:
       deploy:
         skip_cleanup: true
         provider: script
-        script: ./travis_wait "./include/travis/run_in_centos7_docker.sh include/travis/copr-deploy.sh"
+        script: ./travis_wait "./include/travis/run_in_centos7_docker.sh ./include/travis/copr-deploy.sh"
         on:
           all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,10 @@ jobs:
         - ./include/travis/virus-scan.sh
     - stage: test
       env: Type='mock build'
-      language: generic
+      language: node_js
+      node_js: 8
       script:
         - cd node-libzfs
-        - docker exec -ti mock bash -c "yum install -y rpkg"
-        - docker exec -ti mock bash -c "/builddir/node-libzfs rpkg make-source"
         - npm run mock
     - stage: deploy
       env: Type='libzfs-sys'

--- a/node-libzfs/Makefile
+++ b/node-libzfs/Makefile
@@ -1,0 +1,6 @@
+NAME            := iml-node-libzfs
+PACKAGE_VERSION := 0.1.13
+DIST_VERSION    := $(PACKAGE_VERSION)
+PACKAGE_RELEASE := 1
+
+include ../include/rpm.mk

--- a/node-libzfs/iml-node-libzfs.spec
+++ b/node-libzfs/iml-node-libzfs.spec
@@ -26,6 +26,7 @@ Requires: nodejs
 Implements a binding layer from node to rust-libzfs.
 
 %prep
+%setup
 npm i neon-cli@0.1.22
 %nodejs_fixdep -r neon-cli
 

--- a/node-libzfs/iml-node-libzfs.spec
+++ b/node-libzfs/iml-node-libzfs.spec
@@ -1,14 +1,14 @@
-%{?!package_release: %define package_release 1}
-
 %define base_name node-libzfs
 Name:       iml-%{base_name}
 Version:    0.1.13
-Release:    %{package_release}%{?dist}
+Release:    1%{?dist}
 Summary:    Implements a binding layer from node to rust-libzfs
 License:    MIT
 Group:      System Environment/Libraries
 URL:        https://github.com/intel-hpdd/rust-libzfs/tree/master/%{base_name}
-Source0:    http://registry.npmjs.org/@iml/%{base_name}/-/%{base_name}-%{version}.tgz
+# Forcing local source because rpkg in copr does not seem to have a way
+# to build source in the same way a package manager would.
+Source0:    %{name}-%{version}.tgz
 
 ExclusiveArch: %{nodejs_arches}
 
@@ -26,7 +26,6 @@ Requires: nodejs
 Implements a binding layer from node to rust-libzfs.
 
 %prep
-%setup -q -n package
 npm i neon-cli@0.1.22
 %nodejs_fixdep -r neon-cli
 

--- a/node-libzfs/package.json
+++ b/node-libzfs/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "premock": "docker run  -dit --privileged --name mock intelhpdd/mock /usr/sbin/init",
     "mock": "cd ../ && docker cp -a ./ mock:/builddir",
-    "postmock": "docker exec -ti mock bash -xec 'bash -xe /builddir/node-libzfs/mock-build.sh'",
+    "postmock": "docker exec -ti mock bash -xec 'bash -xe cd /builddir/node-libzfs && rpkg make-source && ./mock-build.sh'",
     "install": "neon build"
   }
 }

--- a/node-libzfs/package.json
+++ b/node-libzfs/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "premock": "docker run  -dit --privileged --name mock intelhpdd/mock /usr/sbin/init",
     "mock": "cd ../ && docker cp -a ./ mock:/builddir",
-    "postmock": "docker exec -ti mock bash -xec 'bash -xe cd /builddir/node-libzfs && rpkg make-source && ./mock-build.sh'",
+    "postmock": "docker exec -ti mock bash -xec 'cd /builddir/node-libzfs && rpkg make-source && ./mock-build.sh'",
     "install": "neon build"
   }
 }


### PR DESCRIPTION
With the new way of publishing in `Copr`, we
are using `rpkg` which seems to build `Source0` from the current dir.

This is an issue, as `npm` packages (the current `Source0`)
are published with the top-level dir having the name
`package`.

This causes a variant between how `rpkg` packages source,
and `npm`'s packaged source.

To work around this for now, force `Source0` to be local.

Signed-off-by: Joe Grund <joe.grund@intel.com>