### PR TITLE
Add guid prop to dataset + encode / decode + getDs fn

### DIFF
--- a/Fable.Import.NodeLibzfs/fable/Fable.Import.NodeLibzfs.fsproj
+++ b/Fable.Import.NodeLibzfs/fable/Fable.Import.NodeLibzfs.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="Meta.props" />
   <PropertyGroup>
-    <Version>0.2.1</Version>
+    <Version>0.2.2</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/Fable.Import.NodeLibzfs/test/NodeLibzfs.Test.fs
+++ b/Fable.Import.NodeLibzfs/test/NodeLibzfs.Test.fs
@@ -232,3 +232,644 @@ test "decode / encode whole tree" <| fun () ->
     match decoded with
         | Ok x -> Matchers.toMatchSnapshot (encodePretty (VDev.Encode x))
         | Error e -> failwith e
+
+test "decode / encode pool" <| fun () ->
+    let pool = """
+{
+  "name": "test",
+  "guid": "14919184393193585238",
+  "health": "ONLINE",
+  "hostname": "localhost.localdomain",
+  "hostid": 3914625515,
+  "state": "ACTIVE",
+  "readonly": false,
+  "size": 83886080,
+  "vdev": {
+    "Root": {
+      "children": [
+        {
+          "Mirror": {
+            "children": [
+              {
+                "Disk": {
+                  "guid": "0xBE4606AF1C39DC3F",
+                  "state": "ONLINE",
+                  "path": "/dev/sdb1",
+                  "dev_id": "ata-VBOX_HARDDISK_081118FC1221NCJ6G8G1-part1",
+                  "phys_path": "pci-0000:00:0d.0-ata-2.0",
+                  "whole_disk": true,
+                  "is_log": null
+                }
+              },
+              {
+                "Disk": {
+                  "guid": "0xCC43D91716DA2522",
+                  "state": "ONLINE",
+                  "path": "/dev/sdc1",
+                  "dev_id": "ata-VBOX_HARDDISK_081118FC1221NCJ6G8G2-part1",
+                  "phys_path": "pci-0000:00:0d.0-ata-3.0",
+                  "whole_disk": true,
+                  "is_log": null
+                }
+              }
+            ],
+            "is_log": false
+          }
+        }
+      ],
+      "spares": [
+        {
+          "Disk": {
+            "guid": "0x4DD5D18F6C1F6B34",
+            "state": "ONLINE",
+            "path": "/dev/sde1",
+            "dev_id": "ata-VBOX_HARDDISK_081118FC1221NCJ6G8G4-part1",
+            "phys_path": "pci-0000:00:0d.0-ata-5.0",
+            "whole_disk": true,
+            "is_log": null
+          }
+        },
+        {
+          "Disk": {
+            "guid": "0x58650FD679A8842D",
+            "state": "ONLINE",
+            "path": "/dev/sdf1",
+            "dev_id": "ata-VBOX_HARDDISK_081118FC1221NCJ6G8G5-part1",
+            "phys_path": "pci-0000:00:0d.0-ata-6.0",
+            "whole_disk": true,
+            "is_log": null
+          }
+        }
+      ],
+      "cache": [
+        {
+          "Disk": {
+            "guid": "0x70008C8B94F8AFA8",
+            "state": "ONLINE",
+            "path": "/dev/sdd1",
+            "dev_id": "ata-VBOX_HARDDISK_081118FC1221NCJ6G8G3-part1",
+            "phys_path": "pci-0000:00:0d.0-ata-4.0",
+            "whole_disk": true,
+            "is_log": null
+          }
+        }
+      ]
+    }
+  },
+  "props": [],
+  "datasets": [
+    {
+      "name": "test/ds2",
+      "guid": "11387853141151442667",
+      "kind": "filesystem",
+      "props": [
+        {
+          "name": "name",
+          "value": "test/ds2"
+        },
+        {
+          "name": "type",
+          "value": "filesystem"
+        },
+        {
+          "name": "creation",
+          "value": "1522333734"
+        },
+        {
+          "name": "used",
+          "value": "24576"
+        },
+        {
+          "name": "available",
+          "value": "41751040"
+        },
+        {
+          "name": "referenced",
+          "value": "24576"
+        },
+        {
+          "name": "compressratio",
+          "value": "1.00x"
+        },
+        {
+          "name": "mounted",
+          "value": "yes"
+        },
+        {
+          "name": "quota",
+          "value": "0"
+        },
+        {
+          "name": "reservation",
+          "value": "0"
+        },
+        {
+          "name": "recordsize",
+          "value": "131072"
+        },
+        {
+          "name": "mountpoint",
+          "value": "/test/ds2"
+        },
+        {
+          "name": "sharenfs",
+          "value": "off"
+        },
+        {
+          "name": "checksum",
+          "value": "on"
+        },
+        {
+          "name": "compression",
+          "value": "off"
+        },
+        {
+          "name": "atime",
+          "value": "on"
+        },
+        {
+          "name": "devices",
+          "value": "on"
+        },
+        {
+          "name": "exec",
+          "value": "on"
+        },
+        {
+          "name": "setuid",
+          "value": "on"
+        },
+        {
+          "name": "readonly",
+          "value": "off"
+        },
+        {
+          "name": "zoned",
+          "value": "off"
+        },
+        {
+          "name": "snapdir",
+          "value": "hidden"
+        },
+        {
+          "name": "aclinherit",
+          "value": "restricted"
+        },
+        {
+          "name": "createtxg",
+          "value": "6638"
+        },
+        {
+          "name": "canmount",
+          "value": "on"
+        },
+        {
+          "name": "xattr",
+          "value": "on"
+        },
+        {
+          "name": "copies",
+          "value": "1"
+        },
+        {
+          "name": "version",
+          "value": "5"
+        },
+        {
+          "name": "utf8only",
+          "value": "off"
+        },
+        {
+          "name": "normalization",
+          "value": "none"
+        },
+        {
+          "name": "casesensitivity",
+          "value": "sensitive"
+        },
+        {
+          "name": "vscan",
+          "value": "off"
+        },
+        {
+          "name": "nbmand",
+          "value": "off"
+        },
+        {
+          "name": "sharesmb",
+          "value": "off"
+        },
+        {
+          "name": "refquota",
+          "value": "0"
+        },
+        {
+          "name": "refreservation",
+          "value": "0"
+        },
+        {
+          "name": "guid",
+          "value": "11387853141151442667"
+        },
+        {
+          "name": "primarycache",
+          "value": "all"
+        },
+        {
+          "name": "secondarycache",
+          "value": "all"
+        },
+        {
+          "name": "usedbysnapshots",
+          "value": "0"
+        },
+        {
+          "name": "usedbydataset",
+          "value": "24576"
+        },
+        {
+          "name": "usedbychildren",
+          "value": "0"
+        },
+        {
+          "name": "usedbyrefreservation",
+          "value": "0"
+        },
+        {
+          "name": "logbias",
+          "value": "latency"
+        },
+        {
+          "name": "dedup",
+          "value": "off"
+        },
+        {
+          "name": "mlslabel",
+          "value": "none"
+        },
+        {
+          "name": "sync",
+          "value": "standard"
+        },
+        {
+          "name": "dnodesize",
+          "value": "legacy"
+        },
+        {
+          "name": "refcompressratio",
+          "value": "1.00x"
+        },
+        {
+          "name": "written",
+          "value": "24576"
+        },
+        {
+          "name": "logicalused",
+          "value": "12288"
+        },
+        {
+          "name": "logicalreferenced",
+          "value": "12288"
+        },
+        {
+          "name": "volmode",
+          "value": "default"
+        },
+        {
+          "name": "filesystem_limit",
+          "value": "18446744073709551615"
+        },
+        {
+          "name": "snapshot_limit",
+          "value": "18446744073709551615"
+        },
+        {
+          "name": "filesystem_count",
+          "value": "18446744073709551615"
+        },
+        {
+          "name": "snapshot_count",
+          "value": "18446744073709551615"
+        },
+        {
+          "name": "snapdev",
+          "value": "hidden"
+        },
+        {
+          "name": "acltype",
+          "value": "off"
+        },
+        {
+          "name": "context",
+          "value": "none"
+        },
+        {
+          "name": "fscontext",
+          "value": "none"
+        },
+        {
+          "name": "defcontext",
+          "value": "none"
+        },
+        {
+          "name": "rootcontext",
+          "value": "none"
+        },
+        {
+          "name": "relatime",
+          "value": "off"
+        },
+        {
+          "name": "redundant_metadata",
+          "value": "all"
+        },
+        {
+          "name": "overlay",
+          "value": "off"
+        }
+      ]
+    },
+    {
+      "name": "test/ds",
+      "guid": "9760213047416233279",
+      "kind": "filesystem",
+      "props": [
+        {
+          "name": "name",
+          "value": "test/ds"
+        },
+        {
+          "name": "type",
+          "value": "filesystem"
+        },
+        {
+          "name": "creation",
+          "value": "1521929884"
+        },
+        {
+          "name": "used",
+          "value": "24576"
+        },
+        {
+          "name": "available",
+          "value": "41751040"
+        },
+        {
+          "name": "referenced",
+          "value": "24576"
+        },
+        {
+          "name": "compressratio",
+          "value": "1.00x"
+        },
+        {
+          "name": "mounted",
+          "value": "yes"
+        },
+        {
+          "name": "quota",
+          "value": "0"
+        },
+        {
+          "name": "reservation",
+          "value": "0"
+        },
+        {
+          "name": "recordsize",
+          "value": "131072"
+        },
+        {
+          "name": "mountpoint",
+          "value": "/test/ds"
+        },
+        {
+          "name": "sharenfs",
+          "value": "off"
+        },
+        {
+          "name": "checksum",
+          "value": "on"
+        },
+        {
+          "name": "compression",
+          "value": "off"
+        },
+        {
+          "name": "atime",
+          "value": "on"
+        },
+        {
+          "name": "devices",
+          "value": "on"
+        },
+        {
+          "name": "exec",
+          "value": "on"
+        },
+        {
+          "name": "setuid",
+          "value": "on"
+        },
+        {
+          "name": "readonly",
+          "value": "off"
+        },
+        {
+          "name": "zoned",
+          "value": "off"
+        },
+        {
+          "name": "snapdir",
+          "value": "hidden"
+        },
+        {
+          "name": "aclinherit",
+          "value": "restricted"
+        },
+        {
+          "name": "createtxg",
+          "value": "6"
+        },
+        {
+          "name": "canmount",
+          "value": "on"
+        },
+        {
+          "name": "xattr",
+          "value": "on"
+        },
+        {
+          "name": "copies",
+          "value": "1"
+        },
+        {
+          "name": "version",
+          "value": "5"
+        },
+        {
+          "name": "utf8only",
+          "value": "off"
+        },
+        {
+          "name": "normalization",
+          "value": "none"
+        },
+        {
+          "name": "casesensitivity",
+          "value": "sensitive"
+        },
+        {
+          "name": "vscan",
+          "value": "off"
+        },
+        {
+          "name": "nbmand",
+          "value": "off"
+        },
+        {
+          "name": "sharesmb",
+          "value": "off"
+        },
+        {
+          "name": "refquota",
+          "value": "0"
+        },
+        {
+          "name": "refreservation",
+          "value": "0"
+        },
+        {
+          "name": "guid",
+          "value": "9760213047416233279"
+        },
+        {
+          "name": "primarycache",
+          "value": "all"
+        },
+        {
+          "name": "secondarycache",
+          "value": "all"
+        },
+        {
+          "name": "usedbysnapshots",
+          "value": "0"
+        },
+        {
+          "name": "usedbydataset",
+          "value": "24576"
+        },
+        {
+          "name": "usedbychildren",
+          "value": "0"
+        },
+        {
+          "name": "usedbyrefreservation",
+          "value": "0"
+        },
+        {
+          "name": "logbias",
+          "value": "latency"
+        },
+        {
+          "name": "dedup",
+          "value": "off"
+        },
+        {
+          "name": "mlslabel",
+          "value": "none"
+        },
+        {
+          "name": "sync",
+          "value": "standard"
+        },
+        {
+          "name": "dnodesize",
+          "value": "legacy"
+        },
+        {
+          "name": "refcompressratio",
+          "value": "1.00x"
+        },
+        {
+          "name": "written",
+          "value": "24576"
+        },
+        {
+          "name": "logicalused",
+          "value": "12288"
+        },
+        {
+          "name": "logicalreferenced",
+          "value": "12288"
+        },
+        {
+          "name": "volmode",
+          "value": "default"
+        },
+        {
+          "name": "filesystem_limit",
+          "value": "18446744073709551615"
+        },
+        {
+          "name": "snapshot_limit",
+          "value": "18446744073709551615"
+        },
+        {
+          "name": "filesystem_count",
+          "value": "18446744073709551615"
+        },
+        {
+          "name": "snapshot_count",
+          "value": "18446744073709551615"
+        },
+        {
+          "name": "snapdev",
+          "value": "hidden"
+        },
+        {
+          "name": "acltype",
+          "value": "off"
+        },
+        {
+          "name": "context",
+          "value": "none"
+        },
+        {
+          "name": "fscontext",
+          "value": "none"
+        },
+        {
+          "name": "defcontext",
+          "value": "none"
+        },
+        {
+          "name": "rootcontext",
+          "value": "none"
+        },
+        {
+          "name": "relatime",
+          "value": "off"
+        },
+        {
+          "name": "redundant_metadata",
+          "value": "all"
+        },
+        {
+          "name": "overlay",
+          "value": "off"
+        },
+        {
+          "name": "lustre:mgsnode",
+          "value": "10.14.82.0@tcp:10.14.82.1@tcp"
+        }
+      ]
+    }
+  ]
+}
+"""
+
+    let decoded = Pool.decoder pool
+
+    match decoded with
+        | Ok x -> Matchers.toMatchSnapshot (encodePretty (Pool.encode x))
+        | Error e -> failwith e

--- a/Fable.Import.NodeLibzfs/test/__snapshots__/NodeLibzfs.Test.fs.snap
+++ b/Fable.Import.NodeLibzfs/test/__snapshots__/NodeLibzfs.Test.fs.snap
@@ -175,6 +175,640 @@ exports[`decode / encode RaidZ 2`] = `
 }"
 `;
 
+exports[`decode / encode pool 1`] = `
+"{
+    \\"name\\": \\"test\\",
+    \\"guid\\": \\"14919184393193585238\\",
+    \\"health\\": \\"ONLINE\\",
+    \\"hostname\\": \\"localhost.localdomain\\",
+    \\"hostid\\": null,
+    \\"state\\": \\"ACTIVE\\",
+    \\"readonly\\": false,
+    \\"size\\": 83886080,
+    \\"vdev\\": {
+        \\"Root\\": {
+            \\"children\\": [
+                {
+                    \\"Mirror\\": {
+                        \\"children\\": [
+                            {
+                                \\"Disk\\": {
+                                    \\"guid\\": \\"0xBE4606AF1C39DC3F\\",
+                                    \\"state\\": \\"ONLINE\\",
+                                    \\"path\\": \\"/dev/sdb1\\",
+                                    \\"dev_id\\": \\"ata-VBOX_HARDDISK_081118FC1221NCJ6G8G1-part1\\",
+                                    \\"phys_path\\": \\"pci-0000:00:0d.0-ata-2.0\\",
+                                    \\"whole_disk\\": true,
+                                    \\"is_log\\": null
+                                }
+                            },
+                            {
+                                \\"Disk\\": {
+                                    \\"guid\\": \\"0xCC43D91716DA2522\\",
+                                    \\"state\\": \\"ONLINE\\",
+                                    \\"path\\": \\"/dev/sdc1\\",
+                                    \\"dev_id\\": \\"ata-VBOX_HARDDISK_081118FC1221NCJ6G8G2-part1\\",
+                                    \\"phys_path\\": \\"pci-0000:00:0d.0-ata-3.0\\",
+                                    \\"whole_disk\\": true,
+                                    \\"is_log\\": null
+                                }
+                            }
+                        ],
+                        \\"is_log\\": false
+                    }
+                }
+            ],
+            \\"spares\\": [
+                {
+                    \\"Disk\\": {
+                        \\"guid\\": \\"0x4DD5D18F6C1F6B34\\",
+                        \\"state\\": \\"ONLINE\\",
+                        \\"path\\": \\"/dev/sde1\\",
+                        \\"dev_id\\": \\"ata-VBOX_HARDDISK_081118FC1221NCJ6G8G4-part1\\",
+                        \\"phys_path\\": \\"pci-0000:00:0d.0-ata-5.0\\",
+                        \\"whole_disk\\": true,
+                        \\"is_log\\": null
+                    }
+                },
+                {
+                    \\"Disk\\": {
+                        \\"guid\\": \\"0x58650FD679A8842D\\",
+                        \\"state\\": \\"ONLINE\\",
+                        \\"path\\": \\"/dev/sdf1\\",
+                        \\"dev_id\\": \\"ata-VBOX_HARDDISK_081118FC1221NCJ6G8G5-part1\\",
+                        \\"phys_path\\": \\"pci-0000:00:0d.0-ata-6.0\\",
+                        \\"whole_disk\\": true,
+                        \\"is_log\\": null
+                    }
+                }
+            ],
+            \\"cache\\": [
+                {
+                    \\"Disk\\": {
+                        \\"guid\\": \\"0x70008C8B94F8AFA8\\",
+                        \\"state\\": \\"ONLINE\\",
+                        \\"path\\": \\"/dev/sdd1\\",
+                        \\"dev_id\\": \\"ata-VBOX_HARDDISK_081118FC1221NCJ6G8G3-part1\\",
+                        \\"phys_path\\": \\"pci-0000:00:0d.0-ata-4.0\\",
+                        \\"whole_disk\\": true,
+                        \\"is_log\\": null
+                    }
+                }
+            ]
+        }
+    },
+    \\"props\\": [],
+    \\"datasets\\": [
+        {
+            \\"name\\": \\"test/ds2\\",
+            \\"guid\\": \\"11387853141151442667\\",
+            \\"kind\\": \\"filesystem\\",
+            \\"props\\": [
+                {
+                    \\"name\\": \\"name\\",
+                    \\"value\\": \\"test/ds2\\"
+                },
+                {
+                    \\"name\\": \\"type\\",
+                    \\"value\\": \\"filesystem\\"
+                },
+                {
+                    \\"name\\": \\"creation\\",
+                    \\"value\\": \\"1522333734\\"
+                },
+                {
+                    \\"name\\": \\"used\\",
+                    \\"value\\": \\"24576\\"
+                },
+                {
+                    \\"name\\": \\"available\\",
+                    \\"value\\": \\"41751040\\"
+                },
+                {
+                    \\"name\\": \\"referenced\\",
+                    \\"value\\": \\"24576\\"
+                },
+                {
+                    \\"name\\": \\"compressratio\\",
+                    \\"value\\": \\"1.00x\\"
+                },
+                {
+                    \\"name\\": \\"mounted\\",
+                    \\"value\\": \\"yes\\"
+                },
+                {
+                    \\"name\\": \\"quota\\",
+                    \\"value\\": \\"0\\"
+                },
+                {
+                    \\"name\\": \\"reservation\\",
+                    \\"value\\": \\"0\\"
+                },
+                {
+                    \\"name\\": \\"recordsize\\",
+                    \\"value\\": \\"131072\\"
+                },
+                {
+                    \\"name\\": \\"mountpoint\\",
+                    \\"value\\": \\"/test/ds2\\"
+                },
+                {
+                    \\"name\\": \\"sharenfs\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"checksum\\",
+                    \\"value\\": \\"on\\"
+                },
+                {
+                    \\"name\\": \\"compression\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"atime\\",
+                    \\"value\\": \\"on\\"
+                },
+                {
+                    \\"name\\": \\"devices\\",
+                    \\"value\\": \\"on\\"
+                },
+                {
+                    \\"name\\": \\"exec\\",
+                    \\"value\\": \\"on\\"
+                },
+                {
+                    \\"name\\": \\"setuid\\",
+                    \\"value\\": \\"on\\"
+                },
+                {
+                    \\"name\\": \\"readonly\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"zoned\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"snapdir\\",
+                    \\"value\\": \\"hidden\\"
+                },
+                {
+                    \\"name\\": \\"aclinherit\\",
+                    \\"value\\": \\"restricted\\"
+                },
+                {
+                    \\"name\\": \\"createtxg\\",
+                    \\"value\\": \\"6638\\"
+                },
+                {
+                    \\"name\\": \\"canmount\\",
+                    \\"value\\": \\"on\\"
+                },
+                {
+                    \\"name\\": \\"xattr\\",
+                    \\"value\\": \\"on\\"
+                },
+                {
+                    \\"name\\": \\"copies\\",
+                    \\"value\\": \\"1\\"
+                },
+                {
+                    \\"name\\": \\"version\\",
+                    \\"value\\": \\"5\\"
+                },
+                {
+                    \\"name\\": \\"utf8only\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"normalization\\",
+                    \\"value\\": \\"none\\"
+                },
+                {
+                    \\"name\\": \\"casesensitivity\\",
+                    \\"value\\": \\"sensitive\\"
+                },
+                {
+                    \\"name\\": \\"vscan\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"nbmand\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"sharesmb\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"refquota\\",
+                    \\"value\\": \\"0\\"
+                },
+                {
+                    \\"name\\": \\"refreservation\\",
+                    \\"value\\": \\"0\\"
+                },
+                {
+                    \\"name\\": \\"guid\\",
+                    \\"value\\": \\"11387853141151442667\\"
+                },
+                {
+                    \\"name\\": \\"primarycache\\",
+                    \\"value\\": \\"all\\"
+                },
+                {
+                    \\"name\\": \\"secondarycache\\",
+                    \\"value\\": \\"all\\"
+                },
+                {
+                    \\"name\\": \\"usedbysnapshots\\",
+                    \\"value\\": \\"0\\"
+                },
+                {
+                    \\"name\\": \\"usedbydataset\\",
+                    \\"value\\": \\"24576\\"
+                },
+                {
+                    \\"name\\": \\"usedbychildren\\",
+                    \\"value\\": \\"0\\"
+                },
+                {
+                    \\"name\\": \\"usedbyrefreservation\\",
+                    \\"value\\": \\"0\\"
+                },
+                {
+                    \\"name\\": \\"logbias\\",
+                    \\"value\\": \\"latency\\"
+                },
+                {
+                    \\"name\\": \\"dedup\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"mlslabel\\",
+                    \\"value\\": \\"none\\"
+                },
+                {
+                    \\"name\\": \\"sync\\",
+                    \\"value\\": \\"standard\\"
+                },
+                {
+                    \\"name\\": \\"dnodesize\\",
+                    \\"value\\": \\"legacy\\"
+                },
+                {
+                    \\"name\\": \\"refcompressratio\\",
+                    \\"value\\": \\"1.00x\\"
+                },
+                {
+                    \\"name\\": \\"written\\",
+                    \\"value\\": \\"24576\\"
+                },
+                {
+                    \\"name\\": \\"logicalused\\",
+                    \\"value\\": \\"12288\\"
+                },
+                {
+                    \\"name\\": \\"logicalreferenced\\",
+                    \\"value\\": \\"12288\\"
+                },
+                {
+                    \\"name\\": \\"volmode\\",
+                    \\"value\\": \\"default\\"
+                },
+                {
+                    \\"name\\": \\"filesystem_limit\\",
+                    \\"value\\": \\"18446744073709551615\\"
+                },
+                {
+                    \\"name\\": \\"snapshot_limit\\",
+                    \\"value\\": \\"18446744073709551615\\"
+                },
+                {
+                    \\"name\\": \\"filesystem_count\\",
+                    \\"value\\": \\"18446744073709551615\\"
+                },
+                {
+                    \\"name\\": \\"snapshot_count\\",
+                    \\"value\\": \\"18446744073709551615\\"
+                },
+                {
+                    \\"name\\": \\"snapdev\\",
+                    \\"value\\": \\"hidden\\"
+                },
+                {
+                    \\"name\\": \\"acltype\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"context\\",
+                    \\"value\\": \\"none\\"
+                },
+                {
+                    \\"name\\": \\"fscontext\\",
+                    \\"value\\": \\"none\\"
+                },
+                {
+                    \\"name\\": \\"defcontext\\",
+                    \\"value\\": \\"none\\"
+                },
+                {
+                    \\"name\\": \\"rootcontext\\",
+                    \\"value\\": \\"none\\"
+                },
+                {
+                    \\"name\\": \\"relatime\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"redundant_metadata\\",
+                    \\"value\\": \\"all\\"
+                },
+                {
+                    \\"name\\": \\"overlay\\",
+                    \\"value\\": \\"off\\"
+                }
+            ]
+        },
+        {
+            \\"name\\": \\"test/ds\\",
+            \\"guid\\": \\"9760213047416233279\\",
+            \\"kind\\": \\"filesystem\\",
+            \\"props\\": [
+                {
+                    \\"name\\": \\"name\\",
+                    \\"value\\": \\"test/ds\\"
+                },
+                {
+                    \\"name\\": \\"type\\",
+                    \\"value\\": \\"filesystem\\"
+                },
+                {
+                    \\"name\\": \\"creation\\",
+                    \\"value\\": \\"1521929884\\"
+                },
+                {
+                    \\"name\\": \\"used\\",
+                    \\"value\\": \\"24576\\"
+                },
+                {
+                    \\"name\\": \\"available\\",
+                    \\"value\\": \\"41751040\\"
+                },
+                {
+                    \\"name\\": \\"referenced\\",
+                    \\"value\\": \\"24576\\"
+                },
+                {
+                    \\"name\\": \\"compressratio\\",
+                    \\"value\\": \\"1.00x\\"
+                },
+                {
+                    \\"name\\": \\"mounted\\",
+                    \\"value\\": \\"yes\\"
+                },
+                {
+                    \\"name\\": \\"quota\\",
+                    \\"value\\": \\"0\\"
+                },
+                {
+                    \\"name\\": \\"reservation\\",
+                    \\"value\\": \\"0\\"
+                },
+                {
+                    \\"name\\": \\"recordsize\\",
+                    \\"value\\": \\"131072\\"
+                },
+                {
+                    \\"name\\": \\"mountpoint\\",
+                    \\"value\\": \\"/test/ds\\"
+                },
+                {
+                    \\"name\\": \\"sharenfs\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"checksum\\",
+                    \\"value\\": \\"on\\"
+                },
+                {
+                    \\"name\\": \\"compression\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"atime\\",
+                    \\"value\\": \\"on\\"
+                },
+                {
+                    \\"name\\": \\"devices\\",
+                    \\"value\\": \\"on\\"
+                },
+                {
+                    \\"name\\": \\"exec\\",
+                    \\"value\\": \\"on\\"
+                },
+                {
+                    \\"name\\": \\"setuid\\",
+                    \\"value\\": \\"on\\"
+                },
+                {
+                    \\"name\\": \\"readonly\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"zoned\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"snapdir\\",
+                    \\"value\\": \\"hidden\\"
+                },
+                {
+                    \\"name\\": \\"aclinherit\\",
+                    \\"value\\": \\"restricted\\"
+                },
+                {
+                    \\"name\\": \\"createtxg\\",
+                    \\"value\\": \\"6\\"
+                },
+                {
+                    \\"name\\": \\"canmount\\",
+                    \\"value\\": \\"on\\"
+                },
+                {
+                    \\"name\\": \\"xattr\\",
+                    \\"value\\": \\"on\\"
+                },
+                {
+                    \\"name\\": \\"copies\\",
+                    \\"value\\": \\"1\\"
+                },
+                {
+                    \\"name\\": \\"version\\",
+                    \\"value\\": \\"5\\"
+                },
+                {
+                    \\"name\\": \\"utf8only\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"normalization\\",
+                    \\"value\\": \\"none\\"
+                },
+                {
+                    \\"name\\": \\"casesensitivity\\",
+                    \\"value\\": \\"sensitive\\"
+                },
+                {
+                    \\"name\\": \\"vscan\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"nbmand\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"sharesmb\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"refquota\\",
+                    \\"value\\": \\"0\\"
+                },
+                {
+                    \\"name\\": \\"refreservation\\",
+                    \\"value\\": \\"0\\"
+                },
+                {
+                    \\"name\\": \\"guid\\",
+                    \\"value\\": \\"9760213047416233279\\"
+                },
+                {
+                    \\"name\\": \\"primarycache\\",
+                    \\"value\\": \\"all\\"
+                },
+                {
+                    \\"name\\": \\"secondarycache\\",
+                    \\"value\\": \\"all\\"
+                },
+                {
+                    \\"name\\": \\"usedbysnapshots\\",
+                    \\"value\\": \\"0\\"
+                },
+                {
+                    \\"name\\": \\"usedbydataset\\",
+                    \\"value\\": \\"24576\\"
+                },
+                {
+                    \\"name\\": \\"usedbychildren\\",
+                    \\"value\\": \\"0\\"
+                },
+                {
+                    \\"name\\": \\"usedbyrefreservation\\",
+                    \\"value\\": \\"0\\"
+                },
+                {
+                    \\"name\\": \\"logbias\\",
+                    \\"value\\": \\"latency\\"
+                },
+                {
+                    \\"name\\": \\"dedup\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"mlslabel\\",
+                    \\"value\\": \\"none\\"
+                },
+                {
+                    \\"name\\": \\"sync\\",
+                    \\"value\\": \\"standard\\"
+                },
+                {
+                    \\"name\\": \\"dnodesize\\",
+                    \\"value\\": \\"legacy\\"
+                },
+                {
+                    \\"name\\": \\"refcompressratio\\",
+                    \\"value\\": \\"1.00x\\"
+                },
+                {
+                    \\"name\\": \\"written\\",
+                    \\"value\\": \\"24576\\"
+                },
+                {
+                    \\"name\\": \\"logicalused\\",
+                    \\"value\\": \\"12288\\"
+                },
+                {
+                    \\"name\\": \\"logicalreferenced\\",
+                    \\"value\\": \\"12288\\"
+                },
+                {
+                    \\"name\\": \\"volmode\\",
+                    \\"value\\": \\"default\\"
+                },
+                {
+                    \\"name\\": \\"filesystem_limit\\",
+                    \\"value\\": \\"18446744073709551615\\"
+                },
+                {
+                    \\"name\\": \\"snapshot_limit\\",
+                    \\"value\\": \\"18446744073709551615\\"
+                },
+                {
+                    \\"name\\": \\"filesystem_count\\",
+                    \\"value\\": \\"18446744073709551615\\"
+                },
+                {
+                    \\"name\\": \\"snapshot_count\\",
+                    \\"value\\": \\"18446744073709551615\\"
+                },
+                {
+                    \\"name\\": \\"snapdev\\",
+                    \\"value\\": \\"hidden\\"
+                },
+                {
+                    \\"name\\": \\"acltype\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"context\\",
+                    \\"value\\": \\"none\\"
+                },
+                {
+                    \\"name\\": \\"fscontext\\",
+                    \\"value\\": \\"none\\"
+                },
+                {
+                    \\"name\\": \\"defcontext\\",
+                    \\"value\\": \\"none\\"
+                },
+                {
+                    \\"name\\": \\"rootcontext\\",
+                    \\"value\\": \\"none\\"
+                },
+                {
+                    \\"name\\": \\"relatime\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"redundant_metadata\\",
+                    \\"value\\": \\"all\\"
+                },
+                {
+                    \\"name\\": \\"overlay\\",
+                    \\"value\\": \\"off\\"
+                },
+                {
+                    \\"name\\": \\"lustre:mgsnode\\",
+                    \\"value\\": \\"10.14.82.0@tcp:10.14.82.1@tcp\\"
+                }
+            ]
+        }
+    ]
+}"
+`;
+
 exports[`decode / encode whole tree 1`] = `
 Result {
   "data": VDev {

--- a/libzfs/src/vdev.rs
+++ b/libzfs/src/vdev.rs
@@ -29,7 +29,7 @@ pub enum VDev {
         cache: Vec<VDev>,
     },
     Disk {
-        guid: Option<String>,
+        guid: Option<u64>,
         state: String,
         path: String,
         dev_id: Option<String>,
@@ -38,7 +38,7 @@ pub enum VDev {
         is_log: Option<bool>,
     },
     File {
-        guid: Option<String>,
+        guid: Option<u64>,
         state: String,
         path: String,
         is_log: Option<bool>,
@@ -89,9 +89,8 @@ pub fn enumerate_vdev_tree(tree: &nvpair::NvList) -> Result<VDev> {
             .ok()
     }
 
-    fn lookup_guid(tree: &nvpair::NvList) -> Option<String> {
+    fn lookup_guid(tree: &nvpair::NvList) -> Option<u64> {
         tree.lookup_uint64(sys::zpool_config_guid())
-            .map(|x| format!("{:#018X}", x))
             .ok()
     }
 

--- a/node-libzfs/native/Cargo.lock
+++ b/node-libzfs/native/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "node-libzfs"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "libzfs 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/node-libzfs/native/Cargo.toml
+++ b/node-libzfs/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-libzfs"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["IML Team <iml@intel.com>"]
 license = "MIT"
 build = "build.rs"


### PR DESCRIPTION
Add the guid to the top level dataset objects returned.

We need the ds guid, because that's how IML stores it in
corosync.

In addition, add a fn to fetch dataset by name so we
can get the relevant data without pulling all imported pools.

Finally, add thot encode / decode to pools, datasets and props
so we can have a singular point to encode / decode.

Signed-off-by: Joe Grund <joe.grund@intel.com>