### PR TITLE
Bump ZFS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,12 +178,12 @@ dependencies = [
 
 [[package]]
 name = "libzfs"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "cstr-argument 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libzfs-sys 0.5.3",
+ "libzfs-sys 0.5.4",
  "nvpair-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "libzfs-sys"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nvpair-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/libzfs-sys/Cargo.toml
+++ b/libzfs-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libzfs-sys"
-version = "0.5.3"
+version = "0.5.4"
 description = "Rust bindings to libzfs"
 license = "MIT"
 repository = "https://github.com/intel-hpdd/rust-libzfs"

--- a/libzfs-sys/README.md
+++ b/libzfs-sys/README.md
@@ -1,6 +1,6 @@
 # libzfs-sys
 
-Bindings to libzfs 0.7.7. Uses [bindgen](https://github.com/rust-lang-nursery/rust-bindgen).
+Bindings to libzfs 0.7.8. Uses [bindgen](https://github.com/rust-lang-nursery/rust-bindgen).
 
 ## Overview
 
@@ -9,7 +9,7 @@ to the src dir. To rebuild bindings run `cargo build`.
 
 ## ZFS version
 
-These bindings were compiled against ZFS 0.7.7. As `libzfs` is not a stable interface,
+These bindings were compiled against ZFS 0.7.8. As `libzfs` is not a stable interface,
 they should only be used against this version.
 
 ## OS

--- a/libzfs-sys/build.rs
+++ b/libzfs-sys/build.rs
@@ -93,8 +93,8 @@ fn main() {
         .whitelisted_function("zfs_validate_name")
         .whitelisted_function("zprop_free_list")
         .clang_arg("-I/usr/lib/gcc/x86_64-redhat-linux/4.8.2/include/")
-        .clang_arg("-I/usr/src/zfs-0.7.7/lib/libspl/include/")
-        .clang_arg("-I/usr/src/zfs-0.7.7/include/")
+        .clang_arg("-I/usr/src/zfs-0.7.8/lib/libspl/include/")
+        .clang_arg("-I/usr/src/zfs-0.7.8/include/")
         .generate()
         .expect("Unable to generate bindings");
 

--- a/libzfs-sys/src/lib.rs
+++ b/libzfs-sys/src/lib.rs
@@ -15,7 +15,7 @@
 //! to the src dir. To rebuild bindings run `cargo build`.
 //!
 //! ## ZFS version
-//! These bindings were compiled against ZFS 0.7.7. As `libzfs` is not a stable interface,
+//! These bindings were compiled against ZFS 0.7.8. As `libzfs` is not a stable interface,
 //! they should only be used against this version.
 //!
 //! ## OS

--- a/libzfs/Cargo.toml
+++ b/libzfs/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "libzfs"
-version = "0.6.4"
+version = "0.6.5"
 authors = ["IML Team <iml@intel.com>"]
 description = "Rust wrapper around libzfs-sys"
 license = "MIT"
 
 [dependencies]
-libzfs-sys = { path = "../libzfs-sys", version = "0.5.3" }
+libzfs-sys = { path = "../libzfs-sys", version = "0.5.4" }
 nvpair-sys = "0.1"
 serde = "1.0"
 serde_derive = "1.0"

--- a/node-libzfs/native/Cargo.toml
+++ b/node-libzfs/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-libzfs"
-version = "0.1.15"
+version = "0.1.16"
 authors = ["IML Team <iml@intel.com>"]
 license = "MIT"
 build = "build.rs"
@@ -17,4 +17,4 @@ neon = "0.1.22"
 neon-serde = "0.0.3"
 serde = "1.0"
 serde_derive = "1.0"
-libzfs = "0.6.4"
+libzfs = "0.6.5"

--- a/node-libzfs/package.json
+++ b/node-libzfs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@iml/node-libzfs",
-    "version": "0.1.15",
+    "version": "0.1.16",
     "description": "Neon bindings to libzfs",
     "main": "lib/index.js",
     "publishConfig": {


### PR DESCRIPTION
Bump the zfs version used for bindgen
to 0.7.8.

Signed-off-by: Joe Grund <joe.grund@intel.com>